### PR TITLE
fix: build errors on API routes

### DIFF
--- a/pages/api/chat.ts
+++ b/pages/api/chat.ts
@@ -15,7 +15,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     if (!watchlist.length) throw new Error('No tickers provided');
 
     const rawData = await Promise.all(
-      watchlist.map(sym => getQuote(sym).then(q => ({ symbol: sym, quote: q, shortStats: await getShortStats(sym) })))
+      watchlist.map(async sym => {
+        const quote = await getQuote(sym);
+        const shortStats = await getShortStats(sym);
+        return { symbol: sym, quote, shortStats };
+      })
     );
     const candidates = screenSqueezers(rawData, DEFAULT_PARAMS);
 


### PR DESCRIPTION
## Summary
- Fixed async/await syntax error in pages/api/chat.ts that was causing build failures
- The error was due to using `await` inside a non-async callback function
- Converted the map callback to async to properly handle asynchronous operations

## Test plan
- [x] Run `npm run build` - now passes with zero errors
- [x] Verified that all API routes compile successfully

🤖 Generated with [Claude Code](https://claude.ai/code)